### PR TITLE
Add LTX-2.3 Distilled FP8 T2V ComfyUI workflow

### DIFF
--- a/LTX-2.3_Distilled_FP8_T2V.json
+++ b/LTX-2.3_Distilled_FP8_T2V.json
@@ -1,0 +1,934 @@
+{
+  "last_node_id": 40,
+  "last_link_id": 48,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "MarkdownNote",
+      "pos": [-1900, 80],
+      "size": [480, 580],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "title": "📦 Model Downloads — LTX-2.3 Distilled FP8",
+      "properties": {},
+      "widgets_values": [
+        "## LTX-2.3 Distilled FP8 — Required Files\n\n### Kijai Split Models\n→ [Kijai/LTX2.3_comfy on HuggingFace](https://huggingface.co/Kijai/LTX2.3_comfy)\n\n**Transformer (FP8 Scaled) → `models/diffusion_models/`**\n- `ltx-2.3-22b-distilled_transformer_only_fp8_scaled.safetensors` _(~23.5 GB)_\n\n**Video VAE → `models/vae/`**\n- `LTX23_video_vae_bf16.safetensors` _(~1.45 GB)_\n\n**Audio VAE → `models/vae/`**\n- `LTX23_audio_vae_bf16.safetensors` _(~365 MB)_\n\n**Text Projection → `models/text_encoders/`**\n- `ltx-2.3_text_projection_bf16.safetensors` _(~2.31 GB)_\n\n### Gemma-3 Text Encoder\n→ [google/gemma-3-12b-it-qat-q4_0-unquantized](https://huggingface.co/google/gemma-3-12b-it-qat-q4_0-unquantized)\n```\ncd models/text_encoders\ngit clone https://huggingface.co/google/gemma-3-12b-it-qat-q4_0-unquantized\n```\n\n### Upscalers → `models/latent_upscale_models/`\n- `ltx-2.3-spatial-upscaler-x2.safetensors`\n  _(from [Lightricks/LTX-2.3](https://huggingface.co/Lightricks/LTX-2.3))_\n\n### Required Custom Nodes (ComfyUI Manager)\n- **KJNodes** — `UnetLoaderKJ`\n  github.com/kijai/ComfyUI-KJNodes\n- **ComfyUI-LTXVideo** — `LTXVConditioning`, etc.\n  github.com/Lightricks/ComfyUI-LTXVideo\n- **VideoHelperSuite** — `VHS_VideoCombine`\n  github.com/Kosinkadink/ComfyUI-VideoHelperSuite"
+      ],
+      "color": "#1a3a2a",
+      "bgcolor": "#1e4a32"
+    },
+    {
+      "id": 2,
+      "type": "MarkdownNote",
+      "pos": [-1900, 700],
+      "size": [480, 340],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "title": "⚡ Distilled FP8 Sampling Settings",
+      "properties": {},
+      "widgets_values": [
+        "## Distilled Model — Recommended Settings\n\n| Setting | Value |\n|---|---|\n| CFG | `1.0` |\n| Stage 1 Steps | `8` |\n| Stage 1 Denoise | `1.0` (full) |\n| Stage 2 Steps | `4` |\n| Stage 2 Denoise | `0.35` (refinement) |\n| Sampler | `euler` |\n| Shift | `8.0` |\n\n### Distilled Sigma Values (for reference)\n`1., 0.99375, 0.9875, 0.98125, 0.975, 0.909375, 0.725, 0.421875, 0.0`\n\n⚠️ The FP8 transformer is **already distilled** — no separate distilled LoRA needed.\n\n💡 Enable the optional **Camera / Motion LoRA** node with **Ctrl+B** to add camera movements.\n\n⚡ For faster generation: use **6 steps** on stage 1 or skip the stage 2 refinement pass entirely."
+      ],
+      "color": "#2a1a3a",
+      "bgcolor": "#3a1e4a"
+    },
+    {
+      "id": 3,
+      "type": "MarkdownNote",
+      "pos": [-1900, 1080],
+      "size": [480, 230],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "title": "📐 Video Dimension Rules",
+      "properties": {},
+      "widgets_values": [
+        "## Video Dimension Rules\n\n- **Width & Height** must be divisible by **64**\n- **Frame Count** must be divisible by **8 + 1**\n  Valid values: 25, 33, 49, 65, **97**, 121, 161, 241…\n- **Stage 1** uses **half** the target output resolution\n  (the spatial upscaler x2 doubles it)\n\n| Output Resolution | Stage 1 Width × Height |\n|---|---|\n| 1536 × 832 | 768 × 416 |\n| 1280 × 720 | 640 × 360 |\n| 1024 × 576 | 512 × 288 |"
+      ],
+      "color": "#2a2a1a",
+      "bgcolor": "#3a3a1e"
+    },
+    {
+      "id": 4,
+      "type": "MarkdownNote",
+      "pos": [-1900, 1350],
+      "size": [480, 230],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "title": "✍️ Prompting Tips for LTX-2.3",
+      "properties": {},
+      "widgets_values": [
+        "## Prompting Tips\n\n1. **Chronological flow** — Use temporal connectors: \"as\", \"then\", \"while\"\n2. **Active verbs** — Present-progressive: \"is walking\", \"is speaking\"\n3. **Audio layer** — Describe full soundscape: ambient, SFX, dialogue\n4. **Speech** — Exact words in quotes: `He says: 'Hello!'`\n5. **Style prefix** — Begin with `Style: cinematic,` …\n6. **No timestamps** — Do not describe scene cuts or timestamps\n\nThe **Prompt Enhancer** (LTXVGemmaEnhancePrompt) automatically expands your raw prompt.\nPress **Ctrl+B** on that node to disable it for precise prompt control."
+      ],
+      "color": "#1a2a3a",
+      "bgcolor": "#1e3a4a"
+    },
+    {
+      "id": 5,
+      "type": "UnetLoaderKJ",
+      "pos": [-1360, 80],
+      "size": [380, 80],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [1]
+        }
+      ],
+      "title": "1a — Transformer (FP8 Scaled)",
+      "properties": {"Node name for S&R": "UnetLoaderKJ"},
+      "widgets_values": [
+        "ltx-2.3-22b-distilled_transformer_only_fp8_scaled.safetensors",
+        "default"
+      ],
+      "color": "#1a3a1a",
+      "bgcolor": "#1e4a1e"
+    },
+    {
+      "id": 6,
+      "type": "VAELoader",
+      "pos": [-1360, 200],
+      "size": [380, 58],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {"name": "VAE", "type": "VAE", "slot_index": 0, "links": [4]}
+      ],
+      "title": "1b — Video VAE",
+      "properties": {"Node name for S&R": "VAELoader"},
+      "widgets_values": ["LTX23_video_vae_bf16.safetensors"],
+      "color": "#1a3a1a",
+      "bgcolor": "#1e4a1e"
+    },
+    {
+      "id": 7,
+      "type": "LTXVAudioVAELoader",
+      "pos": [-1360, 295],
+      "size": [380, 58],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {"name": "Audio VAE", "type": "VAE", "slot_index": 0, "links": [5]}
+      ],
+      "title": "1c — Audio VAE",
+      "properties": {"Node name for S&R": "LTXVAudioVAELoader"},
+      "widgets_values": ["LTX23_audio_vae_bf16.safetensors"],
+      "color": "#1a3a1a",
+      "bgcolor": "#1e4a1e"
+    },
+    {
+      "id": 8,
+      "type": "LTXVGemmaCLIPModelLoader",
+      "pos": [-1360, 390],
+      "size": [380, 106],
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "slot_index": 0,
+          "links": [6, 7, 8]
+        }
+      ],
+      "title": "1d — Gemma-3 + LTX-2.3 Text Projection",
+      "properties": {
+        "Node name for S&R": "LTXVGemmaCLIPModelLoader",
+        "widget_ue_connectable": {"model_path": true, "max_length": true}
+      },
+      "widgets_values": [
+        "gemma-3-12b-it-qat-q4_0-unquantized/model-00001-of-00005.safetensors",
+        "ltx-2.3_text_projection_bf16.safetensors",
+        1024
+      ],
+      "color": "#1a3a1a",
+      "bgcolor": "#1e4a1e"
+    },
+    {
+      "id": 9,
+      "type": "LatentUpscaleModelLoader",
+      "pos": [-1360, 535],
+      "size": [380, 58],
+      "flags": {},
+      "order": 8,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "LATENT_UPSCALE_MODEL",
+          "type": "LATENT_UPSCALE_MODEL",
+          "slot_index": 0,
+          "links": [9]
+        }
+      ],
+      "title": "1e — Spatial Upscaler x2",
+      "properties": {"Node name for S&R": "LatentUpscaleModelLoader"},
+      "widgets_values": ["ltx-2.3-spatial-upscaler-x2.safetensors"],
+      "color": "#1a3a1a",
+      "bgcolor": "#1e4a1e"
+    },
+    {
+      "id": 10,
+      "type": "LoraLoaderModelOnly",
+      "pos": [-1360, 630],
+      "size": [380, 82],
+      "flags": {},
+      "order": 9,
+      "mode": 4,
+      "inputs": [
+        {"name": "model", "type": "MODEL", "link": 1}
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [2, 3]
+        }
+      ],
+      "title": "Camera / Motion LoRA  ← Ctrl+B to enable",
+      "properties": {"Node name for S&R": "LoraLoaderModelOnly"},
+      "widgets_values": ["your_camera_lora.safetensors", 1.0],
+      "color": "#3a2a1a",
+      "bgcolor": "#4a321e"
+    },
+    {
+      "id": 11,
+      "type": "PrimitiveInt",
+      "pos": [-910, 80],
+      "size": [225, 82],
+      "flags": {},
+      "order": 10,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {"name": "INT", "type": "INT", "links": [10]}
+      ],
+      "title": "Width ÷64 (Stage 1 half-res)",
+      "properties": {"Node name for S&R": "PrimitiveInt"},
+      "widgets_values": [768, "fixed"]
+    },
+    {
+      "id": 12,
+      "type": "PrimitiveInt",
+      "pos": [-910, 200],
+      "size": [225, 82],
+      "flags": {},
+      "order": 11,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {"name": "INT", "type": "INT", "links": [11]}
+      ],
+      "title": "Height ÷64 (Stage 1 half-res)",
+      "properties": {"Node name for S&R": "PrimitiveInt"},
+      "widgets_values": [512, "fixed"]
+    },
+    {
+      "id": 13,
+      "type": "PrimitiveInt",
+      "pos": [-910, 320],
+      "size": [225, 82],
+      "flags": {},
+      "order": 12,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {"name": "INT", "type": "INT", "links": [12, 13]}
+      ],
+      "title": "Frame Count (8n+1: 97=4s @ 24fps)",
+      "properties": {"Node name for S&R": "PrimitiveInt"},
+      "widgets_values": [97, "fixed"]
+    },
+    {
+      "id": 14,
+      "type": "PrimitiveFloat",
+      "pos": [-910, 440],
+      "size": [225, 58],
+      "flags": {},
+      "order": 13,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {"name": "FLOAT", "type": "FLOAT", "links": [14]}
+      ],
+      "title": "Frame Rate (fps)",
+      "properties": {"Node name for S&R": "PrimitiveFloat"},
+      "widgets_values": [24.0]
+    },
+    {
+      "id": 16,
+      "type": "PrimitiveStringMultiline",
+      "pos": [-620, 80],
+      "size": [350, 290],
+      "flags": {},
+      "order": 14,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {"name": "STRING", "type": "STRING", "links": [15]}
+      ],
+      "title": "Positive Prompt",
+      "properties": {"Node name for S&R": "PrimitiveStringMultiline"},
+      "widgets_values": [
+        "Style: cinematic documentary. A golden retriever puppy races across a sunlit meadow filled with wildflowers, its tongue lolling happily. The camera pans slowly left as the puppy leaps through tall grass, tail wagging. Morning light catches floating dust motes. Birdsong fills the air while a gentle breeze rustles the flowers. The puppy stops, sniffs curiously at a passing butterfly, then bounds forward again with playful energy."
+      ],
+      "color": "#1a2a3a",
+      "bgcolor": "#1e3a4a"
+    },
+    {
+      "id": 17,
+      "type": "LTXVGemmaEnhancePrompt",
+      "pos": [-620, 415],
+      "size": [350, 130],
+      "flags": {},
+      "order": 23,
+      "mode": 0,
+      "inputs": [
+        {"name": "clip", "type": "CLIP", "link": 6},
+        {"name": "image", "shape": 7, "type": "IMAGE", "link": null},
+        {"name": "prompt", "type": "STRING", "widget": {"name": "prompt"}, "link": 15}
+      ],
+      "outputs": [
+        {"name": "enhanced_prompt", "type": "STRING", "links": [16]}
+      ],
+      "title": "Prompt Enhancer (Gemma)  ← Ctrl+B to disable",
+      "properties": {"Node name for S&R": "LTXVGemmaEnhancePrompt"},
+      "widgets_values": [
+        "",
+        "You are a Creative Assistant. Given a user's raw input prompt describing a scene or concept, expand it into a detailed video generation prompt with specific visuals and integrated audio to guide a text-to-video model.\n\nGuidelines:\n- Strictly follow all aspects of the user's raw input.\n- Use active present-progressive verbs.\n- Maintain chronological flow with temporal connectors.\n- Describe a complete soundscape (ambient, SFX, dialogue).\n- Include exact quoted dialogue ONLY if the user mentions speech.\n- Start with 'Style: <style>,' unless unclear.\n- DO NOT invent camera motion unless requested.\n- Single continuous paragraph. No headings or Markdown.",
+        512,
+        true,
+        42,
+        "randomize"
+      ],
+      "color": "#1a2a3a",
+      "bgcolor": "#1e3a4a"
+    },
+    {
+      "id": 18,
+      "type": "CLIPTextEncode",
+      "pos": [-210, 80],
+      "size": [320, 47],
+      "flags": {"collapsed": true},
+      "order": 24,
+      "mode": 0,
+      "inputs": [
+        {"name": "clip", "type": "CLIP", "link": 7},
+        {"name": "text", "type": "STRING", "widget": {"name": "text"}, "link": 16}
+      ],
+      "outputs": [
+        {"name": "CONDITIONING", "type": "CONDITIONING", "slot_index": 0, "links": [17]}
+      ],
+      "title": "Positive Conditioning",
+      "properties": {"Node name for S&R": "CLIPTextEncode"},
+      "widgets_values": [""],
+      "color": "#1a3a1a",
+      "bgcolor": "#1e4a1e"
+    },
+    {
+      "id": 19,
+      "type": "CLIPTextEncode",
+      "pos": [-210, 185],
+      "size": [320, 165],
+      "flags": {},
+      "order": 15,
+      "mode": 0,
+      "inputs": [
+        {"name": "clip", "type": "CLIP", "link": 8}
+      ],
+      "outputs": [
+        {"name": "CONDITIONING", "type": "CONDITIONING", "slot_index": 0, "links": [18]}
+      ],
+      "title": "Negative Conditioning",
+      "properties": {"Node name for S&R": "CLIPTextEncode"},
+      "widgets_values": [
+        "blurry, low quality, distorted, watermark, text overlay, still frame, duplicate frames, frozen motion, worst quality, overexposed, underexposed, ugly, disfigured"
+      ],
+      "color": "#3a1a1a",
+      "bgcolor": "#4a1e1e"
+    },
+    {
+      "id": 20,
+      "type": "LTXVConditioning",
+      "pos": [-210, 400],
+      "size": [320, 94],
+      "flags": {},
+      "order": 25,
+      "mode": 0,
+      "inputs": [
+        {"name": "positive", "type": "CONDITIONING", "link": 17},
+        {"name": "negative", "type": "CONDITIONING", "link": 18},
+        {"name": "frame_rate", "type": "FLOAT", "widget": {"name": "frame_rate"}, "link": 14}
+      ],
+      "outputs": [
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [19, 21]
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "slot_index": 1,
+          "links": [20, 22]
+        }
+      ],
+      "properties": {"Node name for S&R": "LTXVConditioning"},
+      "widgets_values": [25]
+    },
+    {
+      "id": 21,
+      "type": "EmptyLTXVLatentVideo",
+      "pos": [175, 80],
+      "size": [295, 130],
+      "flags": {},
+      "order": 16,
+      "mode": 0,
+      "inputs": [
+        {"name": "width", "type": "INT", "widget": {"name": "width"}, "link": 10},
+        {"name": "height", "type": "INT", "widget": {"name": "height"}, "link": 11},
+        {"name": "length", "type": "INT", "widget": {"name": "length"}, "link": 12}
+      ],
+      "outputs": [
+        {"name": "LATENT", "type": "LATENT", "slot_index": 0, "links": [23]}
+      ],
+      "title": "Empty Video Latent (Stage 1)",
+      "properties": {"Node name for S&R": "EmptyLTXVLatentVideo"},
+      "widgets_values": [768, 512, 97, 1]
+    },
+    {
+      "id": 22,
+      "type": "LTXVEmptyAudioLatent",
+      "pos": [175, 250],
+      "size": [295, 82],
+      "flags": {},
+      "order": 17,
+      "mode": 0,
+      "inputs": [
+        {"name": "length", "type": "INT", "widget": {"name": "length"}, "link": 13}
+      ],
+      "outputs": [
+        {"name": "LATENT", "type": "LATENT", "slot_index": 0, "links": [24]}
+      ],
+      "title": "Empty Audio Latent",
+      "properties": {"Node name for S&R": "LTXVEmptyAudioLatent"},
+      "widgets_values": [97, 1]
+    },
+    {
+      "id": 23,
+      "type": "LTXVConcatAVLatent",
+      "pos": [175, 380],
+      "size": [295, 82],
+      "flags": {},
+      "order": 26,
+      "mode": 0,
+      "inputs": [
+        {"name": "video_latent", "type": "LATENT", "link": 23},
+        {"name": "audio_latent", "type": "LATENT", "link": 24}
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "slot_index": 0,
+          "links": [25, 26, 27]
+        }
+      ],
+      "title": "Concat A+V Latent",
+      "properties": {"Node name for S&R": "LTXVConcatAVLatent"},
+      "widgets_values": []
+    },
+    {
+      "id": 24,
+      "type": "ModelSamplingLTXV",
+      "pos": [545, 80],
+      "size": [295, 82],
+      "flags": {},
+      "order": 27,
+      "mode": 0,
+      "inputs": [
+        {"name": "model", "type": "MODEL", "link": 2},
+        {"name": "latent", "type": "LATENT", "link": 25}
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [28, 29]
+        }
+      ],
+      "title": "Model Sampling LTX-V (Stage 1)",
+      "properties": {"Node name for S&R": "ModelSamplingLTXV"},
+      "widgets_values": []
+    },
+    {
+      "id": 25,
+      "type": "CFGGuider",
+      "pos": [545, 210],
+      "size": [295, 130],
+      "flags": {},
+      "order": 28,
+      "mode": 0,
+      "inputs": [
+        {"name": "model", "type": "MODEL", "link": 28},
+        {"name": "positive", "type": "CONDITIONING", "link": 19},
+        {"name": "negative", "type": "CONDITIONING", "link": 20}
+      ],
+      "outputs": [
+        {"name": "GUIDER", "type": "GUIDER", "slot_index": 0, "links": [30]}
+      ],
+      "title": "CFG Guider — cfg=1.0 (Distilled)",
+      "properties": {"Node name for S&R": "CFGGuider"},
+      "widgets_values": [1.0]
+    },
+    {
+      "id": 26,
+      "type": "LTXVScheduler",
+      "pos": [545, 385],
+      "size": [295, 130],
+      "flags": {},
+      "order": 28,
+      "mode": 0,
+      "inputs": [
+        {"name": "model", "type": "MODEL", "link": 29},
+        {"name": "latent", "type": "LATENT", "link": 26}
+      ],
+      "outputs": [
+        {"name": "SIGMAS", "type": "SIGMAS", "slot_index": 0, "links": [31]}
+      ],
+      "title": "Stage 1 Scheduler — 8 steps / denoise 1.0",
+      "properties": {"Node name for S&R": "LTXVScheduler"},
+      "widgets_values": [8, 1.0, 0.0, 8.0]
+    },
+    {
+      "id": 27,
+      "type": "RandomNoise",
+      "pos": [545, 555],
+      "size": [295, 82],
+      "flags": {},
+      "order": 18,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {"name": "NOISE", "type": "NOISE", "slot_index": 0, "links": [32]}
+      ],
+      "title": "Random Noise (Stage 1)",
+      "properties": {"Node name for S&R": "RandomNoise"},
+      "widgets_values": [42, "randomize"]
+    },
+    {
+      "id": 28,
+      "type": "KSamplerSelect",
+      "pos": [545, 675],
+      "size": [295, 58],
+      "flags": {},
+      "order": 19,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {"name": "SAMPLER", "type": "SAMPLER", "slot_index": 0, "links": [33]}
+      ],
+      "title": "Sampler — euler",
+      "properties": {"Node name for S&R": "KSamplerSelect"},
+      "widgets_values": ["euler"]
+    },
+    {
+      "id": 29,
+      "type": "SamplerCustomAdvanced",
+      "pos": [915, 200],
+      "size": [345, 130],
+      "flags": {},
+      "order": 29,
+      "mode": 0,
+      "inputs": [
+        {"name": "noise",        "type": "NOISE",   "link": 32},
+        {"name": "guider",       "type": "GUIDER",  "link": 30},
+        {"name": "sampler",      "type": "SAMPLER", "link": 33},
+        {"name": "sigmas",       "type": "SIGMAS",  "link": 31},
+        {"name": "latent_image", "type": "LATENT",  "link": 27}
+      ],
+      "outputs": [
+        {"name": "output",          "type": "LATENT", "slot_index": 0, "links": []},
+        {"name": "denoised_output", "type": "LATENT", "slot_index": 1, "links": [34]}
+      ],
+      "title": "Stage 1 Sampler",
+      "properties": {"Node name for S&R": "SamplerCustomAdvanced"},
+      "widgets_values": []
+    },
+    {
+      "id": 30,
+      "type": "LTXVLatentUpscale",
+      "pos": [1340, 200],
+      "size": [325, 130],
+      "flags": {},
+      "order": 30,
+      "mode": 0,
+      "inputs": [
+        {"name": "samples",       "type": "LATENT",               "link": 34},
+        {"name": "upscale_model", "type": "LATENT_UPSCALE_MODEL", "link": 9}
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "slot_index": 0,
+          "links": [35, 36, 37]
+        }
+      ],
+      "title": "Spatial Upscale x2",
+      "properties": {"Node name for S&R": "LTXVLatentUpscale"},
+      "widgets_values": []
+    },
+    {
+      "id": 31,
+      "type": "ModelSamplingLTXV",
+      "pos": [1340, 380],
+      "size": [325, 82],
+      "flags": {},
+      "order": 31,
+      "mode": 0,
+      "inputs": [
+        {"name": "model",  "type": "MODEL",  "link": 3},
+        {"name": "latent", "type": "LATENT", "link": 35}
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [38, 39]
+        }
+      ],
+      "title": "Model Sampling LTX-V (Stage 2)",
+      "properties": {"Node name for S&R": "ModelSamplingLTXV"},
+      "widgets_values": []
+    },
+    {
+      "id": 32,
+      "type": "CFGGuider",
+      "pos": [1340, 505],
+      "size": [325, 130],
+      "flags": {},
+      "order": 32,
+      "mode": 0,
+      "inputs": [
+        {"name": "model",    "type": "MODEL",        "link": 38},
+        {"name": "positive", "type": "CONDITIONING", "link": 21},
+        {"name": "negative", "type": "CONDITIONING", "link": 22}
+      ],
+      "outputs": [
+        {"name": "GUIDER", "type": "GUIDER", "slot_index": 0, "links": [40]}
+      ],
+      "title": "CFG Guider Stage 2 — cfg=1.0",
+      "properties": {"Node name for S&R": "CFGGuider"},
+      "widgets_values": [1.0]
+    },
+    {
+      "id": 33,
+      "type": "LTXVScheduler",
+      "pos": [1340, 685],
+      "size": [325, 130],
+      "flags": {},
+      "order": 32,
+      "mode": 0,
+      "inputs": [
+        {"name": "model",  "type": "MODEL",  "link": 39},
+        {"name": "latent", "type": "LATENT", "link": 36}
+      ],
+      "outputs": [
+        {"name": "SIGMAS", "type": "SIGMAS", "slot_index": 0, "links": [41]}
+      ],
+      "title": "Stage 2 Scheduler — 4 steps / denoise 0.35",
+      "properties": {"Node name for S&R": "LTXVScheduler"},
+      "widgets_values": [4, 0.35, 0.0, 8.0]
+    },
+    {
+      "id": 34,
+      "type": "RandomNoise",
+      "pos": [1340, 860],
+      "size": [325, 82],
+      "flags": {},
+      "order": 20,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {"name": "NOISE", "type": "NOISE", "slot_index": 0, "links": [42]}
+      ],
+      "title": "Random Noise (Stage 2 — fixed)",
+      "properties": {"Node name for S&R": "RandomNoise"},
+      "widgets_values": [42, "fixed"]
+    },
+    {
+      "id": 35,
+      "type": "KSamplerSelect",
+      "pos": [1340, 980],
+      "size": [325, 58],
+      "flags": {},
+      "order": 21,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {"name": "SAMPLER", "type": "SAMPLER", "slot_index": 0, "links": [43]}
+      ],
+      "title": "Sampler Stage 2 — euler",
+      "properties": {"Node name for S&R": "KSamplerSelect"},
+      "widgets_values": ["euler"]
+    },
+    {
+      "id": 36,
+      "type": "SamplerCustomAdvanced",
+      "pos": [1740, 200],
+      "size": [345, 130],
+      "flags": {},
+      "order": 33,
+      "mode": 0,
+      "inputs": [
+        {"name": "noise",        "type": "NOISE",   "link": 42},
+        {"name": "guider",       "type": "GUIDER",  "link": 40},
+        {"name": "sampler",      "type": "SAMPLER", "link": 43},
+        {"name": "sigmas",       "type": "SIGMAS",  "link": 41},
+        {"name": "latent_image", "type": "LATENT",  "link": 37}
+      ],
+      "outputs": [
+        {"name": "output",          "type": "LATENT", "slot_index": 0, "links": []},
+        {"name": "denoised_output", "type": "LATENT", "slot_index": 1, "links": [44]}
+      ],
+      "title": "Stage 2 Sampler (Refinement)",
+      "properties": {"Node name for S&R": "SamplerCustomAdvanced"},
+      "widgets_values": []
+    },
+    {
+      "id": 37,
+      "type": "LTXVSplitAVLatent",
+      "pos": [2160, 200],
+      "size": [315, 82],
+      "flags": {},
+      "order": 34,
+      "mode": 0,
+      "inputs": [
+        {"name": "samples", "type": "LATENT", "link": 44}
+      ],
+      "outputs": [
+        {"name": "video_latent", "type": "LATENT", "slot_index": 0, "links": [45]},
+        {"name": "audio_latent", "type": "LATENT", "slot_index": 1, "links": [46]}
+      ],
+      "title": "Split Video + Audio Latent",
+      "properties": {"Node name for S&R": "LTXVSplitAVLatent"},
+      "widgets_values": []
+    },
+    {
+      "id": 38,
+      "type": "VAEDecode",
+      "pos": [2550, 130],
+      "size": [295, 82],
+      "flags": {},
+      "order": 35,
+      "mode": 0,
+      "inputs": [
+        {"name": "samples", "type": "LATENT", "link": 45},
+        {"name": "vae",     "type": "VAE",    "link": 4}
+      ],
+      "outputs": [
+        {"name": "IMAGE", "type": "IMAGE", "slot_index": 0, "links": [47]}
+      ],
+      "title": "Decode Video Frames",
+      "properties": {"Node name for S&R": "VAEDecode"},
+      "widgets_values": []
+    },
+    {
+      "id": 39,
+      "type": "LTXVAudioVAEDecode",
+      "pos": [2550, 270],
+      "size": [295, 82],
+      "flags": {},
+      "order": 35,
+      "mode": 0,
+      "inputs": [
+        {"name": "samples", "type": "LATENT", "link": 46},
+        {"name": "vae",     "type": "VAE",    "link": 5}
+      ],
+      "outputs": [
+        {"name": "AUDIO", "type": "AUDIO", "slot_index": 0, "links": [48]}
+      ],
+      "title": "Decode Audio",
+      "properties": {"Node name for S&R": "LTXVAudioVAEDecode"},
+      "widgets_values": []
+    },
+    {
+      "id": 40,
+      "type": "VHS_VideoCombine",
+      "pos": [2920, 130],
+      "size": [370, 420],
+      "flags": {},
+      "order": 36,
+      "mode": 0,
+      "inputs": [
+        {"name": "images", "type": "IMAGE", "link": 47},
+        {"name": "audio",  "shape": 7, "type": "AUDIO", "link": 48}
+      ],
+      "outputs": [
+        {"name": "Filenames", "type": "VHS_FILENAMES", "links": []}
+      ],
+      "title": "Save Video — H.264 MP4",
+      "properties": {"Node name for S&R": "VHS_VideoCombine"},
+      "widgets_values": [
+        24.0,
+        "video/LTX-2.3",
+        false,
+        "video/h264-mp4",
+        {},
+        "auto",
+        "auto"
+      ]
+    }
+  ],
+  "links": [
+    [1,  5,  0, 10, 0, "MODEL"],
+    [2,  10, 0, 24, 0, "MODEL"],
+    [3,  10, 0, 31, 0, "MODEL"],
+    [4,  6,  0, 38, 1, "VAE"],
+    [5,  7,  0, 39, 1, "VAE"],
+    [6,  8,  0, 17, 0, "CLIP"],
+    [7,  8,  0, 18, 0, "CLIP"],
+    [8,  8,  0, 19, 0, "CLIP"],
+    [9,  9,  0, 30, 1, "LATENT_UPSCALE_MODEL"],
+    [10, 11, 0, 21, 0, "INT"],
+    [11, 12, 0, 21, 1, "INT"],
+    [12, 13, 0, 21, 2, "INT"],
+    [13, 13, 0, 22, 0, "INT"],
+    [14, 14, 0, 20, 2, "FLOAT"],
+    [15, 16, 0, 17, 2, "STRING"],
+    [16, 17, 0, 18, 1, "STRING"],
+    [17, 18, 0, 20, 0, "CONDITIONING"],
+    [18, 19, 0, 20, 1, "CONDITIONING"],
+    [19, 20, 0, 25, 1, "CONDITIONING"],
+    [20, 20, 1, 25, 2, "CONDITIONING"],
+    [21, 20, 0, 32, 1, "CONDITIONING"],
+    [22, 20, 1, 32, 2, "CONDITIONING"],
+    [23, 21, 0, 23, 0, "LATENT"],
+    [24, 22, 0, 23, 1, "LATENT"],
+    [25, 23, 0, 24, 1, "LATENT"],
+    [26, 23, 0, 26, 1, "LATENT"],
+    [27, 23, 0, 29, 4, "LATENT"],
+    [28, 24, 0, 25, 0, "MODEL"],
+    [29, 24, 0, 26, 0, "MODEL"],
+    [30, 25, 0, 29, 1, "GUIDER"],
+    [31, 26, 0, 29, 3, "SIGMAS"],
+    [32, 27, 0, 29, 0, "NOISE"],
+    [33, 28, 0, 29, 2, "SAMPLER"],
+    [34, 29, 1, 30, 0, "LATENT"],
+    [35, 30, 0, 31, 1, "LATENT"],
+    [36, 30, 0, 33, 1, "LATENT"],
+    [37, 30, 0, 36, 4, "LATENT"],
+    [38, 31, 0, 32, 0, "MODEL"],
+    [39, 31, 0, 33, 0, "MODEL"],
+    [40, 32, 0, 36, 1, "GUIDER"],
+    [41, 33, 0, 36, 3, "SIGMAS"],
+    [42, 34, 0, 36, 0, "NOISE"],
+    [43, 35, 0, 36, 2, "SAMPLER"],
+    [44, 36, 1, 37, 0, "LATENT"],
+    [45, 37, 0, 38, 0, "LATENT"],
+    [46, 37, 1, 39, 0, "LATENT"],
+    [47, 38, 0, 40, 0, "IMAGE"],
+    [48, 39, 0, 40, 1, "AUDIO"]
+  ],
+  "groups": [
+    {
+      "id": 1,
+      "title": "Step 1 — Load Models",
+      "bounding": [-1395, 50, 425, 740],
+      "color": "#3f7859",
+      "font_size": 20,
+      "flags": {}
+    },
+    {
+      "id": 2,
+      "title": "Step 2 — Video Parameters",
+      "bounding": [-945, 50, 260, 540],
+      "color": "#3f6f9e",
+      "font_size": 20,
+      "flags": {}
+    },
+    {
+      "id": 3,
+      "title": "Step 3 — Prompt",
+      "bounding": [-655, 50, 415, 590],
+      "color": "#3f6f9e",
+      "font_size": 20,
+      "flags": {}
+    },
+    {
+      "id": 4,
+      "title": "Step 4 — Conditioning",
+      "bounding": [-250, 50, 385, 545],
+      "color": "#3f6f9e",
+      "font_size": 20,
+      "flags": {}
+    },
+    {
+      "id": 5,
+      "title": "Step 5 — AV Latent Creation",
+      "bounding": [140, 50, 355, 510],
+      "color": "#5f4f7e",
+      "font_size": 20,
+      "flags": {}
+    },
+    {
+      "id": 6,
+      "title": "Stage 1 — Low-Res Distilled Sampling  (8 Steps · CFG 1.0)",
+      "bounding": [510, 50, 790, 780],
+      "color": "#7e5f2f",
+      "font_size": 20,
+      "flags": {}
+    },
+    {
+      "id": 7,
+      "title": "Spatial Upscale x2  +  Stage 2 Refinement  (4 Steps · CFG 1.0)",
+      "bounding": [1305, 165, 810, 890],
+      "color": "#5f2f7e",
+      "font_size": 20,
+      "flags": {}
+    },
+    {
+      "id": 8,
+      "title": "Decode + Save",
+      "bounding": [2125, 100, 1210, 500],
+      "color": "#2f5f7e",
+      "font_size": 20,
+      "flags": {}
+    }
+  ],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.5,
+      "offset": [1920, 90]
+    }
+  },
+  "version": 0.4
+}


### PR DESCRIPTION
Two-stage text-to-video workflow for the LTX-2.3 22B distilled model using Kijai's FP8 split model files from Kijai/LTX2.3_comfy.

Pipeline overview:
- UnetLoaderKJ → loads fp8 scaled transformer (~23.5 GB)
- VAELoader + LTXVAudioVAELoader → separate video/audio VAEs
- LTXVGemmaCLIPModelLoader → Gemma-3 + LTX-2.3 text projection
- Stage 1: 8-step distilled sampling at half-resolution (CFG 1.0)
- LTXVLatentUpscale: spatial upscale x2 via ltx-2.3-spatial-upscaler
- Stage 2: 4-step refinement at full resolution (denoise 0.35)
- LTXVSplitAVLatent → VAEDecode + LTXVAudioVAEDecode → VHS_VideoCombine

Key settings: CFG=1.0, euler sampler, shift=8.0, 39 nodes, 48 links.
Includes inline docs: model download links, video size rules, prompting tips.

https://claude.ai/code/session_01FNSRFLVa12TLEsr76bRgGc